### PR TITLE
Remove unnecessary imports in Vue 3 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ There are 3 options:
   Set theme based on OS color-scheme
 </summary>
 
-```
+```css
 @media (prefers-color-scheme: dark){
   :root{
     --my-color: #252b30;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 Use CDN:
 
-```
+```html
 <script src="https://cdn.jsdelivr.net/npm/theme-change@2.0.2/index.js"></script>
 ```
 
@@ -64,7 +64,7 @@ useEffect(() => {
 Install: `npm i theme-change --save` and use it in your js file:
 
 ```js
-import { onMounted, onUpdated, onUnmounted } from 'vue'
+import { onMounted } from 'vue'
 import { themeChange } from 'theme-change'
 
 export default {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ useEffect(() => {
 </details>
 <details>
 <summary>
-  or if it's a Vue 3 project: 
+  or if it's a Vue 3 project (using composition API): 
 </summary>
 
 Install: `npm i theme-change --save` and use it in your js file:
@@ -79,7 +79,7 @@ export default {
 </details>
 <details>
 <summary>
-  or if it's a Vue 2 project: 
+  or if it's a Vue 2 project (using options API): 
 </summary>
 
 Install: `npm i theme-change --save` and use it in your js file:


### PR DESCRIPTION
~~Side note: calling the two Vue examples "Vue 2" and "Vue 3" is not accurate as both have composition and options API now.~~ Just updated them as well. 