### PR TITLE
Fix index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'theme-change'{
-  export function themeChange(swap:boolean = true):void
+  export function themeChange(swap?:boolean):void;
 }


### PR DESCRIPTION
I install by npm and use this in my Angular application. but i get an error

```
node_modules/theme-change/index.d.ts:2:31 - error TS2371: A parameter initializer is only allowed in a function or constructor implementation.

2   export function themeChange(swap:boolean = true):void
```

this seem to be due to cannot include default parameters in function type definitions. so i fix it and it works fine.