### PR TITLE
Optional data-key for choosing localStorage key

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,23 @@ If you're using [Purge CSS](https://purgecss.com/), you might need to [safe list
 
 </details>
 
+<details>
+<summary>
+  Using custom localStorage key
+</summary>
+
+If you want to use a custom localStorage key, you can add it to the `data-key` attribute like this:
+
+```html
+<select data-choose-theme data-key="admin-panel">
+
+<button data-key="front-page" data-set-theme="">
+
+<span data-key="premium-user-theme" data-toggle-theme="dark">
+```
+
+</details>
+
 ---
 
 [install-size]: https://badgen.net/bundlephobia/minzip/theme-change?label=bundle%20size&color=purple

--- a/src/btn.js
+++ b/src/btn.js
@@ -1,7 +1,9 @@
 function themeBtn() {
-  (function (theme = localStorage.getItem("theme")) {
+  var btnEl = document.querySelector("[data-set-theme='']")
+  var dataKey = btnEl.getAttribute('data-key');
+  (function (theme = localStorage.getItem(dataKey ? dataKey : "theme")) {
     if (theme != undefined && theme != '') {
-      if (localStorage.getItem("theme") && localStorage.getItem("theme") != '') {
+      if (localStorage.getItem(dataKey ? dataKey : "theme") && localStorage.getItem(dataKey ? dataKey : "theme") != '') {
         document.documentElement.setAttribute("data-theme", theme);
         var btnEl = document.querySelector("[data-set-theme='" + theme.toString() + "']")
         if (btnEl) {
@@ -23,12 +25,12 @@ function themeBtn() {
   [...document.querySelectorAll("[data-set-theme]")].forEach((el) => {
     el.addEventListener("click", function () {
       document.documentElement.setAttribute("data-theme", this.getAttribute('data-set-theme'));
-      localStorage.setItem("theme", document.documentElement.getAttribute('data-theme'));
+      localStorage.setItem(dataKey ? dataKey : "theme", document.documentElement.getAttribute('data-theme'));
       [...document.querySelectorAll("[data-set-theme]")].forEach((el) => {
         el.classList.remove(el.getAttribute('data-act-class'));
       });
-      if (el.getAttribute('data-act-class')) {
-        el.classList.add(el.getAttribute('data-act-class'));
+      if (this.getAttribute('data-act-class')) {
+        this.classList.add(this.getAttribute('data-act-class'))
       }
     });
   });

--- a/src/btn.js
+++ b/src/btn.js
@@ -29,8 +29,8 @@ function themeBtn() {
       [...document.querySelectorAll("[data-set-theme]")].forEach((el) => {
         el.classList.remove(el.getAttribute('data-act-class'));
       });
-      if (this.getAttribute('data-act-class')) {
-        this.classList.add(this.getAttribute('data-act-class'))
+      if (el.getAttribute('data-act-class')) {
+        el.classList.add(el.getAttribute('data-act-class'));
       }
     });
   });

--- a/src/select.js
+++ b/src/select.js
@@ -1,6 +1,8 @@
 function themeSelect() {
-  (function (theme = localStorage.getItem("theme")) {
-    if (localStorage.getItem("theme")) {
+  var selectEl = document.querySelector("select[data-choose-theme]");
+  var dataKey = selectEl.getAttribute('data-key');
+  (function (theme = localStorage.getItem(dataKey ? dataKey : "theme")) {
+    if (localStorage.getItem(dataKey ? dataKey : "theme")) {
       document.documentElement.setAttribute("data-theme", theme);
       var optionToggler = document.querySelector("select[data-choose-theme] [value='" + theme.toString() + "']");
       if (optionToggler) {
@@ -10,12 +12,12 @@ function themeSelect() {
       }
     }
   })();
-  if (document.querySelector('select[data-choose-theme]')) {
+  if (selectEl) {
     [...document.querySelectorAll("select[data-choose-theme]")].forEach((el) => {
       el.addEventListener('change', function () {
         document.documentElement.setAttribute("data-theme", this.value);
-        localStorage.setItem("theme", document.documentElement.getAttribute('data-theme'));
-        [...document.querySelectorAll("select[data-choose-theme] [value='" + localStorage.getItem("theme") + "']")].forEach((el) => {
+        localStorage.setItem(dataKey ? dataKey : "theme", document.documentElement.getAttribute('data-theme'));
+        [...document.querySelectorAll("select[data-choose-theme] [value='" + localStorage.getItem(dataKey ? dataKey : "theme") + "']")].forEach((el) => {
           el.selected = true;
         });
       });

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -1,7 +1,8 @@
 function themeToggle() {
   var toggleEl = document.querySelector("[data-toggle-theme]");
-  (function (theme = localStorage.getItem("theme")) {
-    if (localStorage.getItem("theme")) {
+  var dataKey = toggleEl.getAttribute('data-key');
+  (function (theme = localStorage.getItem(dataKey ? dataKey : "theme")) {
+    if (localStorage.getItem(dataKey ? dataKey : "theme")) {
       document.documentElement.setAttribute("data-theme", theme);
       if (toggleEl) {
         [...document.querySelectorAll("[data-toggle-theme]")].forEach((el) => {
@@ -19,14 +20,14 @@ function themeToggle() {
           if (document.documentElement.getAttribute('data-theme') == themesArray[0]) {
             if (themesArray.length == 1) {
               document.documentElement.removeAttribute("data-theme");
-              localStorage.removeItem("theme");
+              localStorage.removeItem(dataKey ? dataKey : "theme");
             }else{
               document.documentElement.setAttribute("data-theme", themesArray[1]);
-              localStorage.setItem("theme", themesArray[1]);
+              localStorage.setItem(dataKey ? dataKey : "theme", themesArray[1]);
             }
           } else {
             document.documentElement.setAttribute("data-theme", themesArray[0]);
-            localStorage.setItem("theme", themesArray[0]);
+            localStorage.setItem(dataKey ? dataKey : "theme", themesArray[0]);
           }
         }
         [...document.querySelectorAll("[data-toggle-theme]")].forEach((el) => {


### PR DESCRIPTION
If you want to use a custom localStorage key, you can add it to the `data-key` attribute like this:

```html
<select data-choose-theme data-key="admin-panel">

<button data-key="front-page" data-set-theme="">

<span data-key="premium-user-theme" data-toggle-theme="dark">
```

This feature is non-intrusive and doesn't break existing code. You can choose to use data-key to change localStorage key otherwise it will use "theme" by default as the key.

Thank you.