### PR TITLE
modify: react useage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ import { themeChange } from 'theme-change'
 useEffect(() => {
   themeChange(false)
   // 👆 false parameter is required for react project
+  return () => {
+    themeChange(false)
+  }
 }, [])
 ```
 


### PR DESCRIPTION
Modify react useage code in README.

In the original example, within a React (especially Next.js) project, `data-toggle-theme` may not work as expected. For instance, using `data-toggle-theme="dark,light"` could result in the theme always switching to dark, without the ability to switch to light.

```js
// README.md

import { useEffect } from 'react'
import { themeChange } from 'theme-change'

useEffect(() => {
  themeChange(false)
  // 👆 false parameter is required for react project
+  return () => {
+    themeChange(false)
+  }
}, [])
```