### PR TITLE
fix(types): resolve TS7016 by adding types conditions to exports map

### DIFF
--- a/btn.d.ts
+++ b/btn.d.ts
@@ -1,0 +1,2 @@
+export function themeBtn(): void;
+export function themeChange(attach?: boolean): void;

--- a/build.mjs
+++ b/build.mjs
@@ -40,9 +40,12 @@ await Promise.all(
   ]),
 );
 
-copyFileSync(
-  resolve(rootDir, "src/index.d.ts"),
-  resolve(rootDir, "index.d.ts"),
-);
+const declarations = ["index", "btn", "select", "toggle"];
+for (const name of declarations) {
+  copyFileSync(
+    resolve(rootDir, `src/${name}.d.ts`),
+    resolve(rootDir, `${name}.d.ts`),
+  );
+}
 
 console.log("Build complete");

--- a/package.json
+++ b/package.json
@@ -10,10 +10,22 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./index.mjs",
-    "./btn": "./btn.mjs",
-    "./select": "./select.mjs",
-    "./toggle": "./toggle.mjs"
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.mjs"
+    },
+    "./btn": {
+      "types": "./btn.d.ts",
+      "default": "./btn.mjs"
+    },
+    "./select": {
+      "types": "./select.d.ts",
+      "default": "./select.mjs"
+    },
+    "./toggle": {
+      "types": "./toggle.d.ts",
+      "default": "./toggle.mjs"
+    }
   },
   "types": "index.d.ts",
   "files": [
@@ -25,7 +37,10 @@
     "select.mjs",
     "btn.js",
     "btn.mjs",
-    "index.d.ts"
+    "index.d.ts",
+    "btn.d.ts",
+    "select.d.ts",
+    "toggle.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/select.d.ts
+++ b/select.d.ts
@@ -1,0 +1,2 @@
+export function themeSelect(): void;
+export function themeChange(attach?: boolean): void;

--- a/src/btn.d.ts
+++ b/src/btn.d.ts
@@ -1,0 +1,2 @@
+export function themeBtn(): void;
+export function themeChange(attach?: boolean): void;

--- a/src/select.d.ts
+++ b/src/select.d.ts
@@ -1,0 +1,2 @@
+export function themeSelect(): void;
+export function themeChange(attach?: boolean): void;

--- a/src/toggle.d.ts
+++ b/src/toggle.d.ts
@@ -1,0 +1,2 @@
+export function themeToggle(): void;
+export function themeChange(attach?: boolean): void;

--- a/toggle.d.ts
+++ b/toggle.d.ts
@@ -1,0 +1,2 @@
+export function themeToggle(): void;
+export function themeChange(attach?: boolean): void;


### PR DESCRIPTION
## TL;DR

The v3 `package.json` `exports` map uses bare string targets (`"./index.mjs"`) with **no `types` condition**. Under TypeScript's modern module resolution (`node16` / `nodenext` / `bundler`), `exports` is consulted first and the top-level `"types"` fallback is **ignored**, so `import { themeChange } from "theme-change"` resolves to implicit `any` and fails with **TS7016** in `strict` projects.

This PR makes each `exports` entry a `types`-first conditional object and adds the previously-missing type declarations for the `./btn`, `./select`, and `./toggle` subpaths. Runtime resolution is unchanged.

## Problem

Since v3.0.0 introduced the `exports` map, type resolution is broken for any consumer using `moduleResolution` of `node16` / `nodenext` / `bundler` (the modern defaults for Next.js, Vite, Bun, etc.):

1. The resolver reads `package.json` `exports` **first**.
2. `exports["."]` is the bare string `"./index.mjs"` — no `types` condition.
3. Because `exports` exists, the top-level `"types": "index.d.ts"` fallback (and the "sibling `.d.ts`" fallback) is **not used**.
4. The import becomes implicit `any` → **TS7016** under `strict` / `noImplicitAny`.

```
error TS7016: Could not find a declaration file for module 'theme-change'.
'.../node_modules/theme-change/index.mjs' implicitly has an 'any' type.
  There are types at '.../node_modules/theme-change/index.d.ts', but this result
  could not be resolved when respecting package.json "exports".
```

> Note: `moduleResolution: "node"` (legacy node10) does not read `exports`, so this only affects newer configs. **v3.0.0–3.0.2 are all affected.**

## Impact (real-world)

A downstream project (Next.js + Bun, `moduleResolution: "bundler"`, `strict: true`) broke upgrading `2.5.0 → 3.0.2`: `next build`'s TypeScript step exits 1 at `import { themeChange } from "theme-change"`.

## Fix

Give every `exports` entry a `types`-first conditional object (conditions are matched top-to-bottom, so `types` must precede `default`), and add type declarations for the subpath modules, which previously shipped none.

```jsonc
"exports": {
  ".":        { "types": "./index.d.ts",  "default": "./index.mjs" },
  "./btn":    { "types": "./btn.d.ts",    "default": "./btn.mjs" },
  "./select": { "types": "./select.d.ts", "default": "./select.mjs" },
  "./toggle": { "types": "./toggle.d.ts", "default": "./toggle.mjs" }
},
"types": "index.d.ts"
```

- Runtime resolution is unchanged — `default` still points to the `.mjs` files.
- The top-level `"types"` is **kept** as the fallback for legacy `moduleResolution: "node"`.
- The package stays ESM-only; `.d.ts` (not `.d.mts`) is correct because `"type": "module"` already makes it ESM.

## Changes

| File | Change |
|------|--------|
| `package.json` | All four `exports` entries → `types`-first conditional objects; subpath `.d.ts` added to `files`. |
| `src/btn.d.ts`, `src/select.d.ts`, `src/toggle.d.ts` | **New.** Named-export-only declarations matching each module's runtime exports. |
| `build.mjs` | Replaced the single `copyFileSync` with a loop that copies all four `src/*.d.ts` to the package root. |

The new subpath declarations mirror the existing `src/index.d.ts` style and the actual named exports:

```ts
// src/btn.d.ts
export function themeBtn(): void;
export function themeChange(attach?: boolean): void;
// (select.d.ts → themeSelect, toggle.d.ts → themeToggle; both + themeChange)
```

## Verification

**1. `@arethetypeswrong/cli --pack`** — `bundler` and `node16 (from ESM)` are green for all four entry points:

```
"theme-change"            node16 (from ESM): 🟢 (ESM)   bundler: 🟢
"theme-change/btn"        node16 (from ESM): 🟢 (ESM)   bundler: 🟢
"theme-change/select"     node16 (from ESM): 🟢 (ESM)   bundler: 🟢
"theme-change/toggle"     node16 (from ESM): 🟢 (ESM)   bundler: 🟢
```

The only remaining note is `node16 (from CJS): ⚠️ ESM (dynamic import only)` — expected and acceptable for a `"type": "module"` ESM-only package (CJS consumers use dynamic `import()`).

**2. `publint`** → `All good!`

**3. `tsc --noEmit` (strict)** against the packed tarball passes under **both** `moduleResolution: "bundler"` and `"node16"`, including the subpath imports:

```ts
import { themeChange } from "theme-change";
import { themeBtn } from "theme-change/btn";
import { themeSelect } from "theme-change/select";
import { themeToggle } from "theme-change/toggle";
```

**4. Negative control** — reverting only the `exports` to the old bare-string form reproduces the exact TS7016 above, confirming the `types` conditions are what fixes it.

## Notes for the maintainer

- This PR is a **types-only fix** and intentionally does **not** bump the version or edit `CHANGELOG.md`, so you keep control of the release (the publish workflow auto-publishes when the version increases on `master`). A patch release (e.g. `3.0.3`) would be appropriate.
- No runtime/behavior changes; output `.mjs`/`.js` are byte-identical.
- The root `index.d.ts` / `btn.d.ts` / `select.d.ts` / `toggle.d.ts` are regenerated by `build.mjs` (and produced fresh by CI before publish).

## Checklist

- [x] `exports["."]` (and subpaths) have a `types`-first condition.
- [x] `@arethetypeswrong/cli --pack` resolves types under `node16`/`bundler`.
- [x] `publint` is clean.
- [x] `tsc --noEmit` passes under both `bundler` and `node16`.
- [x] Subpath type declarations added (`./btn`, `./select`, `./toggle`).
- [ ] (Maintainer) Version bump + CHANGELOG entry on release.